### PR TITLE
Disable name mangling in dev environment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,8 @@ module.exports = function (grunt) {
                 report: 'min',
                 beautify: {
                     ascii_only: true
-                }
+                },
+                mangle: environment !== 'dev'
             },
             app: {
                 files: {


### PR DESCRIPTION
This allows for proper debugging.
