### PR TITLE
[WIP] Standardize mouse interaction events

### DIFF
--- a/web/src/js/lib/utilities/RenderViewMouseInteractor.js
+++ b/web/src/js/lib/utilities/RenderViewMouseInteractor.js
@@ -58,7 +58,7 @@
         this._dragStart = null;
         this._measuringDrag = true;
         this.renderView.on('c:mousedown', function (evt) {
-            this._dragStart = [evt.offsetX, evt.offsetY];
+            this._dragStart = [evt.pageX, evt.pageY];
         }, this);
 
         this.renderView.on('c:mouseup', function () {
@@ -70,8 +70,8 @@
                 var payload = {
                     event: evt,
                     delta: [
-                        evt.offsetX - this._dragStart[0],
-                        evt.offsetY - this._dragStart[1]
+                        evt.pageX - this._dragStart[0],
+                        evt.pageY - this._dragStart[1]
                     ]
                 };
                 if (evt.button === 0) {
@@ -106,13 +106,13 @@
             if (Math.abs(dtheta) > stepTheta) {
                 this.renderView.viewpoint.theta = this.visModel.incrementTheta(
                     this.renderView.viewpoint.theta, dtheta > 0 ? 1 : -1);
-                this._dragStart = [payload.event.offsetX, payload.event.offsetY];
+                this._dragStart = [payload.event.pageX, payload.event.pageY];
                 this.renderView.showViewpoint();
             }
             else if (Math.abs(dphi) > stepPhi) {
                 this.renderView.viewpoint.phi = this.visModel.incrementPhi(
                     this.renderView.viewpoint.phi, dphi > 0 ? 1 : -1);
-                this._dragStart = [payload.event.offsetX, payload.event.offsetY];
+                this._dragStart = [payload.event.pageX, payload.event.pageY];
                 this.renderView.showViewpoint();
             }
         }, this);


### PR DESCRIPTION
I have changed the drag events to use pageX/pageY because they are more common.  

There is another issue with zooming with the mouse wheel that I haven't fixed yet.  Firefox doesn't support the `mousewheel` event.  Also, the meaning of the delta values returned by browsers is different.  I would propose using https://github.com/brandonaaron/jquery-mousewheel to normalize this rather than trying do so ourselves.  Is it okay to bring in this dependency?
