### PR TITLE
Support layer_color_by in info.json, but do not require it.

### DIFF
--- a/web/src/js/lib/models/RenderingModel.js
+++ b/web/src/js/lib/models/RenderingModel.js
@@ -16,14 +16,34 @@ cinema.models.RenderingModel = Backbone.Model.extend({
     defaults: {
     },
 
+    _computeUnionOfColorBys: function() {
+        var colorBys = [];
+        if (_.has(this.visModel.attributes.metadata, 'layer_color_by')) {
+            var allcbs = [];
+            for (var layer in this.visModel.attributes.metadata.layer_color_by) {
+                if (_.has(this.visModel.attributes.metadata.layer_color_by, layer)) {
+                    allcbs.push(this.visModel.attributes.metadata.layer_color_by[layer]);
+                }
+            }
+            colorBys = _.union.apply(_, allcbs);
+        }
+        return colorBys;
+    },
+
     initializeLookupTables: function() {
+        var colorByFields = this._computeUnionOfColorBys();
         var fields = this.visModel.attributes.metadata.fields;
         for (var fieldCode in fields) {
             if (_.has(fields, fieldCode)) {
                 var fieldName = fields[fieldCode];
-                if (this.initializeLutForFieldToPreset(fieldCode, fieldName, 'spectral')) {
-                    this.fieldNamesToCodes[fieldName] = fieldCode;
-                    this.fieldCodesToNames[fieldCode] = fieldName;
+                // If either 1) this info.json doesn't have the "layer_color_by" in the
+                // metadata section, or 2) it does have it, and this field is in there
+                // somewhere, then we set up ui for this field and initialize a LUT for it.
+                if (_.isEmpty(colorByFields) || _.contains(colorByFields, fieldCode)) {
+                    if (this.initializeLutForFieldToPreset(fieldCode, fieldName, 'spectral')) {
+                        this.fieldNamesToCodes[fieldName] = fieldCode;
+                        this.fieldCodesToNames[fieldCode] = fieldName;
+                    }
                 }
             }
         }

--- a/web/src/templates/lib/colorByChooser.jade
+++ b/web/src/templates/lib/colorByChooser.jade
@@ -1,9 +1,17 @@
 .c-color-by-container
   .c-layer-value-choice
-    each name, field in metadata.fields
-      if metadata.layer_fields[layerId].indexOf(field) >= 0
+    if metadata.layer_color_by && metadata.layer_color_by[layerId]
+      each field in metadata.layer_color_by[layerId]
         .radio.c-color-by-radio
           label
             input(directory-id="#{directoryId}", layer-id="#{layerId}", type="radio", name="color-by-select",
                   value="#{field}")
             = metadata.fields[field]
+    else
+      each name, field in metadata.fields
+        if metadata.layer_fields[layerId].indexOf(field) >= 0
+          .radio.c-color-by-radio
+            label
+              input(directory-id="#{directoryId}", layer-id="#{layerId}", type="radio", name="color-by-select",
+                    value="#{field}")
+              = metadata.fields[field]


### PR DESCRIPTION
This adds the ability to restrict the color by options which show
up in the pipeline widget by adding a layer_color_by section to the
info.json.  Also, any field that shows up in a section within this
new optional layer_color_by will be added to the fields list in the
rendering widget.

If the info.json does not have this section, then all the old
behavior is preserved.
