### PR TITLE
Added some empty implementations to avoid errors due to tight coupling.

### DIFF
--- a/web/src/js/lib/widgets/ProbeRendererWidget.js
+++ b/web/src/js/lib/widgets/ProbeRendererWidget.js
@@ -806,6 +806,8 @@ cinema.views.ProbeRendererWidget = Backbone.View.extend({
    forceRedraw: function () {
       this.render();
    },
+   setLightTerms: function (terms) {},
+   setLight: function(vectorLight) {},
    // end - Method called by the rendering widget
 
    applyLUT: function() {


### PR DESCRIPTION
When we get a chance, we will remove all calls from the render widget
directly to the viewport, and instead raise events on the appropriate
model, which can be handled in the main viewport.
