### PR TITLE
Fix webgl search images

### DIFF
--- a/web/src/js/lib/utilities/WebGlCompositor.js
+++ b/web/src/js/lib/utilities/WebGlCompositor.js
@@ -415,8 +415,6 @@
       bottom = centerY - yscale;
       top = centerY + yscale;
 
-      console.log("orthomatrix: left = " + left + ", right = " + right + ", bottom = " + bottom + ", top = " + top);
-
       mat4.ortho(matrix, left, right, bottom, top, 1.0, -1.0);
     }
 
@@ -475,16 +473,16 @@
 
       gl.finish();
 
-      webglImage = (function convertCanvasToImage(canvas) {
-        // console.log("Attempting to generate png image from webgl canvas");
-        var image = new Image();
-        var dataUrl = canvas.toDataURL('image/png');
-        image.src = dataUrl;
-        //console.log("webglcanvas:");
-        //console.log(canvas);
-        //console.log("Just set image src attribute to: " + dataUrl);
-        return image;
-      })(glCanvas);
+      //webglImage = (function convertCanvasToImage(canvas) {
+      //  // console.log("Attempting to generate png image from webgl canvas");
+      //  var image = new Image();
+      //  var dataUrl = canvas.toDataURL('image/png');
+      //  image.src = dataUrl;
+      //  //console.log("webglcanvas:");
+      //  //console.log(canvas);
+      //  //console.log("Just set image src attribute to: " + dataUrl);
+      //  return image;
+      //})(glCanvas);
     }
 
 
@@ -544,10 +542,13 @@
     }
 
     function getImage() {
-      //var image = new Image();
-      //image.src = glCanvas.toDataURL("image/png");
-      //return image;
-      console.log("Retrieving image generated from webgl canvas: ");
+      webglImage = (function convertCanvasToImage(canvas) {
+        var image = new Image();
+        var dataUrl = canvas.toDataURL('image/png');
+        image.src = dataUrl;
+        return image;
+      })(glCanvas);
+
       return webglImage;
     }
 

--- a/web/src/js/lib/widgets/CompositeSearchPage.js
+++ b/web/src/js/lib/widgets/CompositeSearchPage.js
@@ -68,8 +68,6 @@ cinema.views.CompositeSearchPage = Backbone.View.extend({
     },
 
     handleSearchQuery:  function (event) {
-        console.log("Handling a new search query: ");
-        console.log(event);
         this.clearResults();
         var that = this;
         $('.c-search-page-next-results').hide();

--- a/web/src/js/lib/widgets/VisualizationCompCalcWebGlCanvasWidget.js
+++ b/web/src/js/lib/widgets/VisualizationCompCalcWebGlCanvasWidget.js
@@ -118,15 +118,12 @@ cinema.views.VisualizationCompCalcWebGlCanvasWidget = Backbone.View.extend({
         this.$el.html(cinema.templates.compCalcWebglVisCanvas());
 
         if (this.$('.c-compcalc-webglvis-webgl-canvas').length > 0) {
-            console.log("WE WILL RENDER THIS VIEW!!!");
             var imgDim = this.compositeModel.getImageSize();
 
             var vpDim = [
                 this.$('.c-compcalc-webglvis-webgl-canvas').parent().width(),
                 this.$('.c-compcalc-webglvis-webgl-canvas').parent().height()
             ];
-
-            console.log('in render: viewport dims from parent -> w = ' + vpDim[0] + ', h = ' + vpDim[1]);
 
             $(this.$('.c-compcalc-webglvis-webgl-canvas')[0]).attr({
                 width: vpDim[0],
@@ -157,7 +154,8 @@ cinema.views.VisualizationCompCalcWebGlCanvasWidget = Backbone.View.extend({
             this.yscale = imgAspect / vpAspect;
         }
 
-        console.log("xscale = " + this.xscale + ", yscale = " + this.yscale);
+        //console.log("imgAspect = " + imgAspect + ", vpAspect = " + vpAspect + ", xscale = " +
+        //            this.xscale + ", yscale = " + this.yscale);
     },
 
     _computeLayerOffset: function () {
@@ -372,7 +370,7 @@ cinema.views.VisualizationCompCalcWebGlCanvasWidget = Backbone.View.extend({
             w = this.$el.width(),
             h = this.$el.height();
 
-        if (w === 0 && h === 0) {
+        if ( w === 0 && h === 0 ) {
             w = 400;
             h = 400;
         }
@@ -382,17 +380,14 @@ cinema.views.VisualizationCompCalcWebGlCanvasWidget = Backbone.View.extend({
             height: h
         });
 
-        // console.log("zoom: " + zoomLevel + ", center: " + drawingCenter);
-
         var zoomLevel = this.viewpoint.get('zoom');
         var drawingCenter = this.viewpoint.get('center');
         zoomLevel = zoomLevel / this.naturalZoom;
 
-        console.log("drawImage, w = " + w + ", h = " + h + ", zoom: " + zoomLevel + ", center: " + drawingCenter);
+        // console.log("drawImage, w = " + w + ", h = " + h + ", zoom: " + zoomLevel + ", center: " + drawingCenter);
 
         this._resizeViewport([w, h], this.compositeModel.getImageSize());
         this.webglCompositor.resizeViewport(w, h);
-        // this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel * 2.0, this.yscale / zoomLevel * 2.0, drawingCenter);
         this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel, this.yscale / zoomLevel, drawingCenter);
 
         this.trigger('c:drawn');
@@ -416,15 +411,6 @@ cinema.views.VisualizationCompCalcWebGlCanvasWidget = Backbone.View.extend({
     },
 
     getImage: function () {
-        var compositeCanvas = this.$('.c-compcalc-webglvis-composite-buffer')[0];
-
-        //var image = new Image();
-        //var compositeCanvas = this.$('.c-compcalc-webglvis-webgl-canvas')[0];
-        //compositeCanvas = this.$('.c-compcalc-webglvis-composite-buffer')[0];
-        //image.src = compositeCanvas.toDataURL("image/png");
-        //return image;
-
-        //return compositeCanvas.toDataURL('image/png');
         return this.webglCompositor.getImage();
     },
 

--- a/web/src/js/lib/widgets/VisualizationWebGlCanvasWidget.js
+++ b/web/src/js/lib/widgets/VisualizationWebGlCanvasWidget.js
@@ -145,11 +145,13 @@ cinema.views.VisualizationWebGlCanvasWidget = Backbone.View.extend({
         var vpAspect = viewportDimensions[0] / viewportDimensions[1];
 
         if (vpAspect > imgAspect) {
-            this.xscale = vpAspect;
+            this.naturalZoom = viewportDimensions[1] / imageDimensions[1];
+            this.xscale = vpAspect / imgAspect;
             this.yscale = 1.0;
         } else {
+            this.naturalZoom = viewportDimensions[0] / imageDimensions[0];
             this.xscale = 1.0;
-            this.yscale = 1.0 / vpAspect;
+            this.yscale = imgAspect / vpAspect;
         }
     },
 
@@ -231,19 +233,25 @@ cinema.views.VisualizationWebGlCanvasWidget = Backbone.View.extend({
             w = this.$el.width(),
             h = this.$el.height();
 
+        if ( w === 0 && h === 0 ) {
+            w = 400;
+            h = 400;
+        }
+
         $(webglCanvas).attr({
             width: w,
             height: h
         });
 
-        // console.log("zoom: " + zoomLevel + ", center: " + drawingCenter);
-
         var zoomLevel = this.viewpoint.get('zoom');
         var drawingCenter = this.viewpoint.get('center');
+        zoomLevel = zoomLevel / this.naturalZoom;
+
+        //console.log("drawImage, w = " + w + ", h = " + h + ", zoom: " + zoomLevel + ", center: " + drawingCenter);
 
         this._resizeViewport([w, h], this.compositeModel.getImageSize());
         this.webglCompositor.resizeViewport(w, h);
-        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel * 2.0, this.yscale / zoomLevel * 2.0, drawingCenter);
+        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel, this.yscale / zoomLevel, drawingCenter);
 
         this.trigger('c:drawn');
     },

--- a/web/src/js/lib/widgets/VisualizationWebGlJpgCanvasWidget.js
+++ b/web/src/js/lib/widgets/VisualizationWebGlJpgCanvasWidget.js
@@ -146,11 +146,13 @@ cinema.views.VisualizationWebGlJpgCanvasWidget = Backbone.View.extend({
         var vpAspect = viewportDimensions[0] / viewportDimensions[1];
 
         if (vpAspect > imgAspect) {
-            this.xscale = vpAspect;
+            this.naturalZoom = viewportDimensions[1] / imageDimensions[1];
+            this.xscale = vpAspect / imgAspect;
             this.yscale = 1.0;
         } else {
+            this.naturalZoom = viewportDimensions[0] / imageDimensions[0];
             this.xscale = 1.0;
-            this.yscale = 1.0 / vpAspect;
+            this.yscale = imgAspect / vpAspect;
         }
     },
 
@@ -264,19 +266,25 @@ cinema.views.VisualizationWebGlJpgCanvasWidget = Backbone.View.extend({
             w = this.$el.width(),
             h = this.$el.height();
 
+        if ( w === 0 && h === 0 ) {
+            w = 400;
+            h = 400;
+        }
+
         $(webglCanvas).attr({
             width: w,
             height: h
         });
 
-        // console.log("zoom: " + zoomLevel + ", center: " + drawingCenter);
-
         var zoomLevel = this.viewpoint.get('zoom');
         var drawingCenter = this.viewpoint.get('center');
+        zoomLevel = zoomLevel / this.naturalZoom;
+
+        //console.log("drawImage, w = " + w + ", h = " + h + ", zoom: " + zoomLevel + ", center: " + drawingCenter);
 
         this._resizeViewport([w, h], this.compositeModel.getImageSize());
         this.webglCompositor.resizeViewport(w, h);
-        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel * 2.0, this.yscale / zoomLevel * 2.0, drawingCenter);
+        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel, this.yscale / zoomLevel, drawingCenter);
 
         this.trigger('c:drawn');
     },

--- a/web/src/js/lib/widgets/VisualizationWebGlLightCanvasWidget.js
+++ b/web/src/js/lib/widgets/VisualizationWebGlLightCanvasWidget.js
@@ -174,11 +174,13 @@ cinema.views.VisualizationWebGlLightCanvasWidget = Backbone.View.extend({
         var vpAspect = viewportDimensions[0] / viewportDimensions[1];
 
         if (vpAspect > imgAspect) {
-            this.xscale = vpAspect;
+            this.naturalZoom = viewportDimensions[1] / imageDimensions[1];
+            this.xscale = vpAspect / imgAspect;
             this.yscale = 1.0;
         } else {
+            this.naturalZoom = viewportDimensions[0] / imageDimensions[0];
             this.xscale = 1.0;
-            this.yscale = 1.0 / vpAspect;
+            this.yscale = imgAspect / vpAspect;
         }
     },
 
@@ -431,19 +433,25 @@ cinema.views.VisualizationWebGlLightCanvasWidget = Backbone.View.extend({
             w = this.$el.width(),
             h = this.$el.height();
 
+        if ( w === 0 && h === 0 ) {
+            w = 400;
+            h = 400;
+        }
+
         $(webglCanvas).attr({
             width: w,
             height: h
         });
 
-        // console.log("zoom: " + zoomLevel + ", center: " + drawingCenter);
-
         var zoomLevel = this.viewpoint.get('zoom');
         var drawingCenter = this.viewpoint.get('center');
+        zoomLevel = zoomLevel / this.naturalZoom;
+
+        // console.log("drawImage, w = " + w + ", h = " + h + ", zoom: " + zoomLevel + ", center: " + drawingCenter);
 
         this._resizeViewport([w, h], this.compositeModel.getImageSize());
         this.webglCompositor.resizeViewport(w, h);
-        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel * 2.0, this.yscale / zoomLevel * 2.0, drawingCenter);
+        this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel, this.yscale / zoomLevel, drawingCenter);
 
         this.trigger('c:drawn');
     },

--- a/web/src/js/lib/widgets/VisualizationWebGlLutCanvasWidget.js
+++ b/web/src/js/lib/widgets/VisualizationWebGlLutCanvasWidget.js
@@ -178,8 +178,6 @@ cinema.views.VisualizationWebGlLutCanvasWidget = Backbone.View.extend({
             this.xscale = 1.0;
             this.yscale = imgAspect / vpAspect;
         }
-
-        console.log("xscale = " + this.xscale + ", yscale = " + this.yscale);
     },
 
     _computeLayerOffset: function () {
@@ -333,6 +331,11 @@ cinema.views.VisualizationWebGlLutCanvasWidget = Backbone.View.extend({
             w = this.$el.width(),
             h = this.$el.height();
 
+        if ( w === 0 && h === 0 ) {
+            w = 400;
+            h = 400;
+        }
+
         $(webglCanvas).attr({
             width: w,
             height: h
@@ -342,14 +345,11 @@ cinema.views.VisualizationWebGlLutCanvasWidget = Backbone.View.extend({
 
         var zoomLevel = this.viewpoint.get('zoom');
         var drawingCenter = this.viewpoint.get('center');
-
         zoomLevel = zoomLevel / this.naturalZoom;
 
         this._resizeViewport([w, h], this.compositeModel.getImageSize());
         this.webglCompositor.resizeViewport(w, h);
         this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel, this.yscale / zoomLevel, drawingCenter);
-        // this.webglCompositor.drawDisplayPass(this.xscale / zoomLevel * 2.0, this.yscale / zoomLevel * 2.0, drawingCenter);
-        // this.webglCompositor.drawDisplayPass(this.xscale, this.yscale, drawingCenter);
 
         this.trigger('c:drawn');
     },


### PR DESCRIPTION
This PR fixes issues the webgl canvas widgets had with setting their initial size within the browser viewport.  It also fixes problems that resulted in the search views for those types of data showing no search result images.
